### PR TITLE
投稿データがデータベースに保存できた

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,7 +38,7 @@ class PostsController < ApplicationController
 
   private
   def post_params
-    params.require(:post).permit(:tag, :title, :text, :image).merge(user_id: current_user.id)
+    params.require(:post).permit(:tag_id, :title, :text, :image).merge(user_id: current_user.id)
   end
 
   def set_post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,7 @@
 class Post < ApplicationRecord
-  validates :tag, :title, :text, :image, presence: true
+  validates :tag_id, :title, :text, :image, presence: true
   belongs_to :user
-  has_many :post_tags, dependent: :destroy
-  has_many :tags, through: :post_tags
+  belongs_to :tag
 
   mount_uploader :image, ImageUploader
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,4 +1,0 @@
-class PostTag < ApplicationRecord
-  belongs_to :post
-  belongs_to :tag
-end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,3 @@
 class Tag < ApplicationRecord
   has_many :post_tags, dependent: :destroy
-  has_many :posts, through: :post_tags
 end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <%= form_with(model: @post, local: true) do |form| %>
       <h2>投稿する</h2>
-      <%= form.collection_select :tags_ids, Tag.all, :id, :name, :prompt => "カテゴリーを選択して下さい" %>
+      <%= form.collection_select :tag_id, Tag.all, :id, :name, :prompt => "カテゴリーを選択して下さい" %>
       <%= form.text_field :title, placeholder: "タイトル" %>
       <%= form.file_field :image, placeholder: "写真のURL" %>
       <%= form.text_area :text, placeholder: "投稿内容" , rows: "10" %>

--- a/db/migrate/20200515004250_create_post_tags.rb
+++ b/db/migrate/20200515004250_create_post_tags.rb
@@ -1,9 +1,0 @@
-class CreatePostTags < ActiveRecord::Migration[5.2]
-  def change
-    create_table :post_tags do |t|
-      t.references :post, index: true, foreign_key: true
-      t.references :tag,  index: true, foreign_key: true
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20200515120700_add_tag_to_posts.rb
+++ b/db/migrate/20200515120700_add_tag_to_posts.rb
@@ -1,5 +1,5 @@
 class AddTagToPosts < ActiveRecord::Migration[5.2]
   def change
-    add_column :posts, :tag, :string
+    add_column :posts, :tag_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,15 +12,6 @@
 
 ActiveRecord::Schema.define(version: 2020_05_15_120700) do
 
-  create_table "post_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "post_id"
-    t.bigint "tag_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["post_id"], name: "index_post_tags_on_post_id"
-    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
-  end
-
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "text"
@@ -28,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_120700) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
-    t.string "tag"
+    t.integer "tag_id"
   end
 
   create_table "tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -56,6 +47,4 @@ ActiveRecord::Schema.define(version: 2020_05_15_120700) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "post_tags", "posts"
-  add_foreign_key "post_tags", "tags"
 end


### PR DESCRIPTION
# What
新規投稿で、送信ボタンを押すと元の投稿ページに戻る。
binding.pryでパラメーターを確認すると全てのformの内容が取得できている。
createアクションで、save!メソッドエラーの原因を探る。
https://gyazo.com/b6a6372279e585d91a186fff839accc5
バリデーションで全ての内容が記入済みで送信されなければいけないが、
Validation failed: Tag can't be blank
tagが空で送信されようとしていたことがエラーの原因だった。

# Why
原因は、大まかにいうと２つあった。
１つ目は、投稿が一つに対してtagは一つしかつけられないのにtagsと複数形で登録や取得をしようとしていたこと。
・postモデルのバリデーションのtags_idsをtag_idに修正
・postとtagの多対多の関係になっていたアソシエーションを修正
２つ目は、tagは一つしかつけられないので、投稿postとのアソシエーションは多対一の関係であるのに中間テーブルを作ってしまっていたことにあった。
・中間テーブルを削除
